### PR TITLE
Fix case where gct is None in the metrics aggregation (OpenAI, Gemini)

### DIFF
--- a/core/evaluator.py
+++ b/core/evaluator.py
@@ -116,62 +116,14 @@ def evaluate(
     c_mean_list = bootstrap(compliance_list, np.mean)
 
     return (
-        Metric(
-            values=dc_mean_list,
-            median=np.median(dc_mean_list),
-            min=min(dc_mean_list),
-            max=max(dc_mean_list),
-            std=np.std(dc_mean_list),
-        ),
-        Metric(
-            values=ec_mean_list,
-            median=np.median(ec_mean_list),
-            min=min(ec_mean_list),
-            max=max(ec_mean_list),
-            std=np.std(ec_mean_list),
-        ),
-        Metric(
-            values=c_mean_list,
-            median=np.median(c_mean_list),
-            min=min(c_mean_list),
-            max=max(c_mean_list),
-            std=np.std(c_mean_list),
-        ),
+        Metric.from_values(dc_mean_list),
+        Metric.from_values(ec_mean_list),
+        Metric.from_values(c_mean_list),
         AggregatedPerfMetrics(
-            ttft=Metric(
-                values=ttft_list,
-                median=np.median(ttft_list),
-                min=min(ttft_list),
-                max=max(ttft_list),
-                std=np.std(ttft_list),
-            ),
-            tpot=Metric(
-                values=tpot_list,
-                median=np.median(tpot_list),
-                min=min(tpot_list),
-                max=max(tpot_list),
-                std=np.std(tpot_list),
-            ),
-            tgt=Metric(
-                values=tgt_list,
-                median=np.median(tgt_list),
-                min=min(tgt_list),
-                max=max(tgt_list),
-                std=np.std(tgt_list),
-            ),
-            gct=Metric(
-                values=gct_list,
-                median=np.median(gct_list) if len(gct_list) > 0 else None,
-                min=min(gct_list) if len(gct_list) > 0 else None,
-                max=max(gct_list) if len(gct_list) > 0 else None,
-                std=np.std(gct_list) if len(gct_list) > 0 else None,
-            ),# gct is nodefined for remote engines run on cloud like openai, for which we can not measure the compilation time
+            ttft=Metric.from_values(ttft_list),
+            tpot=Metric.from_values(tpot_list),
+            tgt=Metric.from_values(tgt_list),
+            gct=Metric.from_values(gct_list),
         ),
-        Metric(
-            values=output_tokens_list,
-            median=np.median(output_tokens_list),
-            min=min(output_tokens_list),
-            max=max(output_tokens_list),
-            std=np.std(output_tokens_list),
-        ),
+        Metric.from_values(output_tokens_list),
     )

--- a/core/evaluator.py
+++ b/core/evaluator.py
@@ -161,11 +161,11 @@ def evaluate(
             ),
             gct=Metric(
                 values=gct_list,
-                median=np.median(gct_list),
-                min=min(gct_list),
-                max=max(gct_list),
-                std=np.std(gct_list),
-            ),
+                median=np.median(gct_list) if len(gct_list) > 0 else None,
+                min=min(gct_list) if len(gct_list) > 0 else None,
+                max=max(gct_list) if len(gct_list) > 0 else None,
+                std=np.std(gct_list) if len(gct_list) > 0 else None,
+            ),# gct is nodefined for remote engines run on cloud like openai, for which we can not measure the compilation time
         ),
         Metric(
             values=output_tokens_list,

--- a/core/types.py
+++ b/core/types.py
@@ -1,10 +1,11 @@
+import numpy as np
 from enum import Enum
 from uuid import uuid4
 from dataclasses import dataclass, field
 from typing import List, Dict, Any, Optional
 
 from core.messages import Message
-from core.utils import safe_divide, safe_subtract
+from core.utils import safe_divide, safe_subtract, safe_reduce
 
 
 Schema = Dict[str, Any]
@@ -125,10 +126,20 @@ class PerfMetrics:
 @dataclass
 class Metric:
     values: List[float] = field(default_factory=list)
-    std: Optional[float] = None
     min: Optional[float] = None
     max: Optional[float] = None
     median: Optional[float] = None
+    std: Optional[float] = None
+
+    @classmethod
+    def from_values(cls, values: List[float]) -> "Metric":
+        return cls(
+            values=values,
+            min=safe_reduce(values, min),
+            max=safe_reduce(values, max),
+            median=safe_reduce(values, np.median),
+            std=safe_reduce(values, np.std),
+        )
 
 
 @dataclass

--- a/core/utils.py
+++ b/core/utils.py
@@ -40,9 +40,15 @@ def safe_subtract(a: Optional[float], b: Optional[float]) -> Optional[float]:
 
 
 def safe_min(a: int, b: Optional[int]) -> int:
+    """Safely finds the minimum of a and b, returning a if b is None."""
     if b is None:
         return a
     return min(a, b)
+
+
+def safe_reduce(a: List[T], func: Callable[[List[T]], T]) -> Optional[T]:
+    """Safely reduces a list of values using a function, returning None if the list is empty."""
+    return func(a) if a else None
 
 
 def format_metric(metric: "Metric", details: bool = False) -> str:


### PR DESCRIPTION
Fix issue #3 


`python3 -m run --engine openai --tasks Glaiveai2K --limit 5 --save_outputs`

would lead to 

```
  File "/home/saibo/Projects/jsonschemabench/run.py", line 34, in <module>
    bench(
  File "/home/saibo/Projects/jsonschemabench/core/bench.py", line 74, in bench
    dc, ec, cl, pm, ot = evaluate(outputs)
                         ^^^^^^^^^^^^^^^^^
  File "/home/saibo/Projects/jsonschemabench/core/evaluator.py", line 165, in evaluate
    min=min(gct_list),
        ^^^^^^^^^^^^^
ValueError: min() iterable argument is empty
```

After fix, we get:

```
+------------+-------------------+--------------------+-------------+-------------+--------------+-------------+---------+---------------+
|    Task    | Declared coverage | Empirical coverage |  Compliance |   TTFT (s)  |  TPOT (ms)   |   TGT (s)   | GCT (s) | Output tokens |
+------------+-------------------+--------------------+-------------+-------------+--------------+-------------+---------+---------------+
| Glaiveai2K |    1.00 ± 0.00    |    0.80 ± 0.18     | 0.80 ± 0.17 | 0.53 ± 0.17 | 16.15 ± 1.72 | 1.05 ± 0.32 |   n/a   | 37.50 ± 13.39 |
+------------+-------------------+--------------------+-------------+-------------+--------------+-------------+---------+---------------+
Outputs saved to outputs/openai/LutW.jsonl
```